### PR TITLE
Fix : Replaced Hardcoded Dataset Path with Relative Path

### DIFF
--- a/group14 source code.py
+++ b/group14 source code.py
@@ -5,11 +5,20 @@ import cv2
 import numpy as np
 
 # Load the dataset
-file_path = r'C:/Users/KASMYA/OneDrive/Documents/comp science/skindataall.csv'
+import os
+
+# Get the directory where the script is located
+script_dir = os.path.dirname(os.path.abspath(__file__))
+# Create the full path to the CSV file
+file_path = os.path.join(script_dir, 'skindataall.csv')
+
 try:
     skin_data = pd.read_csv(file_path)
 except FileNotFoundError:
-    messagebox.showerror("Error", "Dataset file not found. Please check the file path.")
+    messagebox.showerror("Error", f"Dataset file not found at: {file_path}")
+    exit()
+except Exception as e:
+    messagebox.showerror("Error", f"Error loading dataset: {str(e)}")
     exit()
 
 # Preprocess dataset


### PR DESCRIPTION
** Summary** : 👍 This PR resolves the portability issue caused by a hardcoded absolute path to skindataall.csv. The previous reference restricted functionality to a specific machine, resulting in file-not-found errors for other contributors.

Changes Made:

Updated the dataset reference to use a relative path.

Impact:

Improves accessibility and portability across machines.

Aligns with cross-platform development best practices.

Supports seamless collaboration and onboarding for new contributors.

Related Issue: Closes #6  <!-- Update with actual issue number if it's tracked -->

Let me know if additional cleanup or documentation is needed for this change. 